### PR TITLE
User /user-identity/upsert instead of /user-identity/get-or-create

### DIFF
--- a/app.js
+++ b/app.js
@@ -288,7 +288,7 @@ async function handleMessageHistory() {
                 message.author.id !== "976429060752298044"
               ) {
                 const senderIdentityId = await getIdentityByID(
-                  1,
+                  source.id,
                   message.author.id,
                   message.author.username
                 );

--- a/bounties.js
+++ b/bounties.js
@@ -87,12 +87,12 @@ export const getOrgId = async (guildID) => {
   return data;
 };
 
-export const getIdentityByID = async (originID, userID, username) => {
+export const getIdentityByID = async (sourceID, userID, username) => {
   // console.log(username)
   const payload = {
     identities: [
       {
-        origin_id: originID,
+        source_id: sourceID,
         external_id: userID,
         external_name: username.toString(),
       },
@@ -102,7 +102,7 @@ export const getIdentityByID = async (originID, userID, username) => {
   // const stringified = JSON.stringify(payload);
   // console.log(stringified);
   const endpoint =
-    "https://api.mercantille.xyz/api/v1/user-identity/get-or-create";
+    "https://api.mercantille.xyz/api/v1/user-identity/upsert";
   const response = await fetch(endpoint, {
     method: "POST",
     headers: {
@@ -119,7 +119,7 @@ export const getIdentityByID = async (originID, userID, username) => {
     console.error("Received error from server: %d", response.status);
   }
   // console.log(data.identities)
-  return data.identities[0].id;
+  return data.id;
 };
 
 export const topUp = async (orgID, toUserID, amount, currencyID) => {

--- a/commands/customexec.js
+++ b/commands/customexec.js
@@ -105,7 +105,7 @@ const doExecuteCommand = async (commandDef, payload) => {
   const sourceID = sources.sources[0].id;
   const orgID = sources.sources[0].organization_id;
   const fromUserIdentity = await getIdentityByID(
-    1,
+    sourceID,
     fromUserId,
     fromUser.username
   );

--- a/interactions.js
+++ b/interactions.js
@@ -118,7 +118,7 @@ const handleGiverepCommand = async (payload) => {
     const positiveTopUpResp = await topUp(orgID, toUserId, amount, 1);
     if (!negativeTopUpResp.error) {
       const fromIdentity = await getIdentityByID(
-        1,
+        sourceID,
         fromUser.id,
         fromUser.username
       );
@@ -165,9 +165,10 @@ const handleCheckrepCommand = async (payload) => {
   const fromUser = payload.member.user;
   const guildID = payload.guild_id;
 
-  const fromIdentity = await getIdentityByID(1, fromUser.id, fromUser.username);
   const response = await getOrgId(guildID);
+  const sourceID = response.sources[0].id;
   const orgID = response.sources[0].organization_id;
+  const fromIdentity = await getIdentityByID(sourceID, fromUser.id, fromUser.username);
   const wallets = await getWalletsByID(orgID, fromIdentity);
 
   if (wallets && wallets !== null) {


### PR DESCRIPTION
During development of slack bot it became apparent that we must store user identity in relation to `source_id` instead of `origin_id`: slack user IDs are different for each workspace.

Because of this we are deprecating [`/user-identity/get-or-create`](https://api.mercantille.xyz/docs/#/user-identity/post_v1_user_identity_get_or_create) handle are moving to [`/user-identity/upsert`](https://api.mercantille.xyz/docs/#/user-identity/post_v1_user_identity_upsert) and [`/user-identity/upsert-bulk`](https://api.mercantille.xyz/docs/#/user-identity/post_v1_user_identity_upsert_bulk) handles instead.

This PR replaces usage of "get-or-create" handle with "upsert" handle

